### PR TITLE
Adding message for insufficient funds error in mint dapp (thanks @3xByte)

### DIFF
--- a/nextjs/components/MintWidget/MintWidget.module.scss
+++ b/nextjs/components/MintWidget/MintWidget.module.scss
@@ -17,6 +17,11 @@
 
   .price {
     @apply px-6 py-4;
+
+    .insufficientFunds {
+      @apply block;
+      @apply text-red-500;
+    }
   }
 
   .priceComposition {

--- a/nextjs/components/MintWidget/MintWidget.module.scss
+++ b/nextjs/components/MintWidget/MintWidget.module.scss
@@ -20,6 +20,8 @@
 
     .insufficientFunds {
       @apply block;
+
+      @apply font-bold;
       @apply text-red-500;
     }
   }

--- a/nextjs/components/MintWidget/MintWidget.tsx
+++ b/nextjs/components/MintWidget/MintWidget.tsx
@@ -12,6 +12,7 @@ const MintWidget = () => {
     mintAmount,
     tokenPrice,
     setMintAmount,
+    hasEnoughFunds,
     isReadyToMint,
     mint,
     mintLoading,
@@ -46,6 +47,7 @@ const MintWidget = () => {
 
         <div className={styles.price}>
           <strong>Total price:</strong> {utils.formatEther(tokenPrice.mul(mintAmount))} ETH
+          {!hasEnoughFunds && <span className={styles.insufficientFunds}>Insufficient funds!</span>}
         </div>
 
         <div className={styles.priceComposition}>


### PR DESCRIPTION
As reported by @3xByte the dapp was failing with no feedback if the wallet balance was insufficient to complete the mint transaction.

An error message is now shown under the total price and the mint button is disabled.

Here is a preview:
<img width="375" alt="Screen Shot 2022-11-04 at 14 39 43" src="https://user-images.githubusercontent.com/1532277/199986304-b782bd75-5fe6-4d0b-b3f2-ef24335cf9fa.png">